### PR TITLE
ENGINF-4955 Updating all references of actions/cache@v2 to actions/cache@v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.4] - 2024-12-13
+
+- Bumped references of `actions/cache@v2` to `actions/cache@v4` to address GitHub closing `actions/cache@v2`.
+
 ## [1.2.3] - 2024-10-03
 
 - Update the `typedoc` package to address a high severity vulnerability.


### PR DESCRIPTION
Description of Changes:
Updated all references of actions/cache@v2 to actions/cache@v4

From Github:

Starting February 1st, 2025, we are closing down v1-v2 of [actions/cache](https://app.github.media/e/er?s=88570519&lid=6814&elqTrackId=a3bc821626b94473987e2c1b05d7f97a&elq=d9c6e82124ea4c0c9967f56228fd0d56&elqaid=4282&elqat=1&elqak=8AF5A5B4BDB0473BC910C050E532EFF4973984941B02729379993EBEC8DFA05EB1F2) (read more about it in this [changelog announcement](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=d9c6e82124ea4c0c9967f56228fd0d56&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A5084941B02729379993EBEC8DFA05EB1F2)) as well as all previous versions of the [@actions/cache package](https://app.github.media/e/er?s=88570519&lid=6813&elqTrackId=50ac21f35d544fc981a1f6fc17691756&elq=d9c6e82124ea4c0c9967f56228fd0d56&elqaid=4282&elqat=1&elqak=8AF5661E2DAA849B548228AA9931C3126C9C84941B02729379993EBEC8DFA05EB1F2) in [actions/toolkit](https://app.github.media/e/er?s=88570519&lid=6812&elqTrackId=0b5c70fcb33e4fa3b6eba9d55dbd4f27&elq=d9c6e82124ea4c0c9967f56228fd0d56&elqaid=4282&elqat=1&elqak=8AF533B9911C7B652C3AE6F25753FAAFE7CE84941B02729379993EBEC8DFA05EB1F2). Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.

Steps:

Replace all usages of actions/cache@v1 and actions/cache@v2 with actions/cache@v4 across all repos and actions that are using the old versions.

There should be no additional changes required to support the new version, changing the version reference should be enough

Ensure the actions still run successfully after the version change

## Details
Confirm github actions run as normal after changes.


```
Run actions/cache@v4
  with:
    path: /home/runner/.cache/yarn/v6
    key: Linux-yarn-0195bc57ad3eaef5b05b70171b7ccd78be8574a63748dfa[2](https://github.com/neofinancial/mongo-memory-server-action/actions/runs/12306520632/job/34348400799#step:5:2)c80c048fbc5[3](https://github.com/neofinancial/mongo-memory-server-action/actions/runs/12306520632/job/34348400799#step:5:3)7c0e
    restore-keys: Linux-yarn-
  
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
Cache not found for input keys: Linux-yarn-0195bc57ad3eaef5b05b70171b7ccd78be857[4](https://github.com/neofinancial/mongo-memory-server-action/actions/runs/12306520632/job/34348400799#step:5:4)a63748dfa2c80c048fbc537c0e, Linux-yarn-
```

## Additional context
None.